### PR TITLE
Add Kanban board section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@
 
 <!-- TABLE OF CONTENTS -->
 
+# 📗 Kanban board
+- [Link to Kanabn board](https://github.com/users/PRATAP-KUMAR/projects/3/views/1)
+- [Link to screenshot of the initial state of Kanban board](https://user-images.githubusercontent.com/40719899/210572649-69ff848f-bb24-47f6-8754-8d0b4c6b6fc3.png)
+- [Link to Kanban board GIF](https://user-images.githubusercontent.com/40719899/210572777-c98cb0bd-0ce5-4606-b4c1-7ec6dffeccf6.gif)
+- We are a team of 5 members in this final capstone project
+
 # 📗 Table of Contents
 
 - [📖 About the Project](#about-project)


### PR DESCRIPTION
Hi @TEAM, in this PR,

Added Kanban board section to README as per the [instructions here](https://github.com/microverseinc/curriculum-final-capstone/blob/main/projects/prepare_for_presentation.md#exercise)

- Add a new section to the README file in your project. It should be titled "Kanban board" and it should contain:
a link to your Kanban board.
- a link to the screenshot of the initial state of your Kanban board
- a statement with the final number of team members.